### PR TITLE
Remove `async` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.3
+* Remove `async` function declaration to avoid regenerator runtime / babel-polyfill
+
 # 0.0.2
 * Fix entry point to use built version
 

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ let Form = ({afterInitField = x => x, validate = functions, ...config}) => {
     getNestedSnapshot: () => F.unflattenObject(values(form.fields)),
     getPatch: () =>
       _.omitBy(_.isNil, unmerge(values(config.fields), values(form.fields))),
-    submit: Command(async () => {
+    submit: Command(() => {
       if (_.isEmpty(form.validate()))
-        await config.submit(form.getSnapshot(), form)
+        return config.submit(form.getSnapshot(), form)
       else throw 'Validation Error'
     }),
     get submitError() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/mobx-autoform.js",
   "scripts": {


### PR DESCRIPTION
Remove `async` function declaration to avoid regenerator runtime / babel-polyfill
