### PR TITLE
Fix function validator collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.7
+* Function validator now looks for `validator` instead of `validate` to not clash with the per field validate method
+
 # 0.0.6
 * Add support for validating subsets of the form.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ let form = Form({
   fields: {
     email: {},
     password: {
-      validate: x => !x && ['Password is required'],
+      validator: x => !x && ['Password is required'],
     },
   },
   submit: async snapshot => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/mobx-autoform.js",
   "scripts": {

--- a/validators.js
+++ b/validators.js
@@ -19,8 +19,8 @@ export let functions = (form, fields) => {
   let snapshot = form.getSnapshot()
   return _.flow(
     maybeLimitFields(fields),
-    F.mapValuesIndexed(({ validate = () => {} }, field) =>
-      validate(snapshot[field])
+    F.mapValuesIndexed(({ validator = () => {} }, field) =>
+      validator(snapshot[field])
     ),
     F.compactObject
   )(form.fields)


### PR DESCRIPTION
* Function validator now looks for `validator` instead of `validate` to not clash with the per field validate method
