### PR TITLE
Include already invalid fields when validating single field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.14
+* Fix issue with preserving already invalid fields when validating a field subset
+
 # 0.0.13
 * Validating a field should also include fields which are currently invalid
 

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
     },
     validate: fields =>
       (form.errors = fields
-        ? _.extend(form.errors, validate(form, fields))
-        : validate(form, fields)),
+        ? { ..._.omit(fields, form.errors), ...validate(form, fields) }
+        : validate(form)),
     add: x => extendObservable(form.fields, F.mapValuesIndexed(initField, x)),
   })
   return form

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/mobx-autoform.js",
   "scripts": {


### PR DESCRIPTION
we need to omit the fields being validated from the validation result, otherwise if they do not have validation errors now but had before, they errors are not cleared.