### PR TITLE
feature/16 - add declareClean to Form and Field APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.15
+* add `clean` method to Fields and Forms to allow dirty checking against current values
+
 # 0.0.14
 * Fix issue with preserving already invalid fields when validating a field subset
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ We've looked at just about every single form management package for mobx and rea
 ## Field API
 | prop | description |
 | ---- | ----------- |
-| field | The field key |
-| label | The display label, defaults to _.startCase on field |
-| value | The field's current value. Will default to `''` if no value is provided. |
-| errors | A computed of validation errors for the field |
-| isValid | A computed boolean representing if there are errors |
-| isDirty | A computed boolean representing if the value has changed since the form was instantiated |
-| reset | A method to reset the field back to the value it had when the form was instantiated |
-| validate | A method to validate only the current field |
+| `field` | The field key |
+| `label` | The display label, defaults to _.startCase on field |
+| `value` | The field's current value. Will default to `''` if no value is provided. |
+| `errors` | A computed of validation errors for the field |
+| `isValid` | A computed boolean representing if there are errors |
+| `isDirty` | A computed boolean representing if the value has changed since the form was instantiated |
+| `clean()` | A method to declare the field clean so that isDirty will report changes against its current value rather than its original value |
+| `reset()` | A method to reset the field back to the value it had when the form was instantiated |
+| `validate()` | A method to validate only the current field |
 
 ## Form API
 | prop | description |

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
       field,
       label: x.label || _.startCase(field),
       value: '', // in case no value is provided, avoids controlled vs uncontrolled warning and need for mobx 4
+      cleanValue: x.value || '',
       get errors() {
         return form.errors[field] || []
       },
@@ -23,12 +24,15 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
         return !node.errors.length
       },
       get isDirty() {
-        return changed(node.value, x.value)
+        return changed(node.value, node.cleanValue)
       },
       reset() {
         node.value = F.when(_.isUndefined, '')(x.value)
       },
       validate: () => form.validate([field]),
+      declareClean: () => {
+        node.cleanValue = node.value
+      },
       ...x,
     })
     return afterInitField(node, x)
@@ -57,6 +61,9 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
     },
     get isDirty() {
       return _.some('isDirty', form.fields)
+    },
+    declareClean() {
+      _.invokeMap('declareClean', form.fields)
     },
     // Validation
     errors: {},

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
         node.value = F.when(_.isUndefined, '')(x.value)
       },
       validate: () => form.validate([field]),
-      clean: () => {
+      clean () {
         x.value = node.value
       },
       ...x,

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
       field,
       label: x.label || _.startCase(field),
       value: '', // in case no value is provided, avoids controlled vs uncontrolled warning and need for mobx 4
-      cleanValue: x.value || '',
       get errors() {
         return form.errors[field] || []
       },
@@ -24,14 +23,14 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
         return !node.errors.length
       },
       get isDirty() {
-        return changed(node.value, node.cleanValue)
+        return changed(node.value, x.value)
       },
       reset() {
         node.value = F.when(_.isUndefined, '')(x.value)
       },
       validate: () => form.validate([field]),
-      declareClean: () => {
-        node.cleanValue = node.value
+      clean: () => {
+        x.value = node.value
       },
       ...x,
     })
@@ -62,8 +61,8 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
     get isDirty() {
       return _.some('isDirty', form.fields)
     },
-    declareClean() {
-      _.invokeMap('declareClean', form.fields)
+    clean() {
+      _.invokeMap('clean', form.fields)
     },
     // Validation
     errors: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/mobx-autoform.js",
   "scripts": {


### PR DESCRIPTION
Fixes #16 

### Description
* lets you declare a field clean with its current value so dirty checking only looks for changes from that point on
* adds obvious corresponding form method