### PR TITLE
Fix isDirty v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 0.0.17
+* 0.0.16 v3. Convert other value to a plain javascript object before doing the comparison
+
+# 0.0.17
 * 0.0.16 v2. Convert value to a plain javascript object before doing the comparison
 
 # 0.0.16

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ let Form = ({ afterInitField = x => x, validate = functions, ...config }) => {
         return !node.errors.length
       },
       get isDirty() {
-        return changed(toJS(node.value), x.value)
+        return changed(toJS(node.value), toJS(x.value))
       },
       reset() {
         node.value = F.when(_.isUndefined, '')(x.value)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/mobx-autoform.js",
   "scripts": {


### PR DESCRIPTION
The further fix won't work after `form.clean()` is called. `form.clean` resets a field's "base" value to the current one, which is an observable. This fix should cover us for all cases. If it doesn't work now I'll commit harakiri.