### PR TITLE
Do not use _.cloneDeep. It messes up observable arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.1
+* Bugfix: Use safe clone instead of `_.cloneDeep` internally
+
 # 0.4.0
 * Do not take `path` on `node.remove`. Use `form.getField(path).remove()`
 * Make sure array fields are observables when replacing array values
@@ -5,6 +8,7 @@
 # 0.3.0
 * Add nested fields support
 * Add array fields support
+* Drop `{form,field}.empty` methods.
 
 # 0.2.0
 * Export validators

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ export default ({
       return _.isEmpty(path)
         ? field
         : set(['fields', ...fieldPath(path)], field, tree)
-    })({})(_.cloneDeep(_.defaults({ fields: {} }, config)))
+    })({})(clone(_.defaults({ fields: {} }, config)))
 
   let form = extendObservable(initTree(config), {
     getSnapshot: () => F.flattenObject(form.getNestedSnapshot()),


### PR DESCRIPTION
Instead use _.flow(toJS, _.cloneDeep)