### PR TITLE
Fix nestedSnapshot: unflatten all fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.2
+* Bugfix: Unflatten all fields on `F.getNestedSnapshot`
+
 # 0.4.1
 * Bugfix: Use safe clone instead of `_.cloneDeep` internally
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import F from 'futil'
 import _ from 'lodash/fp'
 import { observable, extendObservable, reaction } from 'mobx'
 import * as validators from './validators'
-import { tokenizePath, safeJoinPaths, gatherValues } from './util'
+import { tokenizePath, safeJoinPaths, gatherFormValues } from './util'
 import { treePath, omitByPrefixes, pickByPrefixes } from './futil'
 import { get, set, toJS } from './mobx'
 export { validators }
@@ -132,7 +132,7 @@ export default ({
   let form = extendObservable(initTree(config), {
     // Ideally we'd just do toJS(form.value) but we have to maintain backwards
     // compatibility and include fields with undefined values as well
-    getSnapshot: () => F.flattenObject(toJS(gatherValues(form))),
+    getSnapshot: () => F.flattenObject(toJS(gatherFormValues(form))),
     getNestedSnapshot: () => F.unflattenObject(form.getSnapshot()),
     getPatch: () => unmerge(saved.value, toJS(state.value)),
     submit: Command(() => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -239,14 +239,18 @@ describe('Methods and computeds', () => {
   it('getNestedSnapshot()', () => {
     expect(form.getNestedSnapshot()).toStrictEqual({
       location: {
-        'country.state': { zip: '07016', name: undefined },
+        country: {
+          state: { zip: '07016', name: undefined },
+        },
         addresses: [{ street: 'Meridian', tenants: ['John'] }],
       },
     })
     form.getField('location.addresses.0').remove()
     expect(form.getNestedSnapshot()).toStrictEqual({
       location: {
-        'country.state': { zip: '07016', name: undefined },
+        country: {
+          state: { zip: '07016', name: undefined },
+        },
       },
     })
   })

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp'
+import { reduceTreePost, treePath } from './futil'
 
 export let tokenizePath = path => {
   if (_.isNumber(path)) path = [_.toString(path)]
@@ -13,3 +14,10 @@ export let safeJoinPaths = _.flow(
   _.map(x => (x.includes('.') && !x.includes('[') ? `["${x}"]` : x)),
   _.join('.')
 )
+
+// Walk tree of fields and gather values. If the field has no value,
+// still set a key for the field but with a value of undefined
+export let gatherValues = reduceTreePost(x => x.fields)((tree, x, ...xs) =>
+  // Only walk leaf nodes
+  !_.isEmpty(x.fields) ? tree : _.set(treePath(x, ...xs), x.value, tree)
+)({})

--- a/src/util.js
+++ b/src/util.js
@@ -17,7 +17,8 @@ export let safeJoinPaths = _.flow(
 
 // Walk tree of fields and gather values. If the field has no value,
 // still set a key for the field but with a value of undefined
-export let gatherValues = reduceTreePost(x => x.fields)((tree, x, ...xs) =>
+// TODO: futil F.mapTree
+export let gatherFormValues = reduceTreePost(x => x.fields)((tree, x, ...xs) =>
   // Only walk leaf nodes
   !_.isEmpty(x.fields) ? tree : _.set(treePath(x, ...xs), x.value, tree)
 )({})

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,4 +1,4 @@
-import { tokenizePath, safeJoinPaths } from './util'
+import { tokenizePath, safeJoinPaths, gatherValues } from './util'
 
 it('tokenizePath', () => {
   expect(tokenizePath()).toEqual([])
@@ -15,4 +15,16 @@ it('safeJoinPaths', () => {
   expect(safeJoinPaths()).toEqual('')
   expect(safeJoinPaths(['a', '["b.c"]', 0, 'd'])).toEqual('a.["b.c"].0.d')
   expect(safeJoinPaths(['a', 'b.c', 0, 'd'])).toEqual('a.["b.c"].0.d')
+})
+
+it('gatherValues', () => {
+  expect(
+    gatherValues({
+      fields: {
+        'a.b': { fields: [{ value: 1 }, { value: 2 }] },
+        c: { fields: { d: {} } },
+        e: { value: [1, 2], fields: [{ value: 1 }, { value: 2 }] },
+      },
+    })
+  ).toStrictEqual({ 'a.b': [1, 2], c: { d: undefined }, e: [1, 2] })
 })

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,4 +1,4 @@
-import { tokenizePath, safeJoinPaths, gatherValues } from './util'
+import { tokenizePath, safeJoinPaths, gatherFormValues } from './util'
 
 it('tokenizePath', () => {
   expect(tokenizePath()).toEqual([])
@@ -17,9 +17,9 @@ it('safeJoinPaths', () => {
   expect(safeJoinPaths(['a', 'b.c', 0, 'd'])).toEqual('a.["b.c"].0.d')
 })
 
-it('gatherValues', () => {
+it('gatherFormValues', () => {
   expect(
-    gatherValues({
+    gatherFormValues({
       fields: {
         'a.b': { fields: [{ value: 1 }, { value: 2 }] },
         c: { fields: { d: {} } },


### PR DESCRIPTION
I thought `F.unflattenObject` would handle nested dotted paths but we have to do that manually now by calling `F.flattenObject` first