### PR TITLE
Detect field removals on getPatch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.4.3
+* Detect field removals on `getPatch()`
+
 # 0.4.2
 * Bugfix: Unflatten all fields on `F.getNestedSnapshot`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8723,7 +8723,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { get, set, toJS } from './mobx'
 export { validators }
 
 let clone = _.flow(toJS, _.cloneDeep)
-let unmerge = _.flow(F.simpleDiff, _.mapValues('to'))
+let unmerge = _.flow(F.diff, _.mapValues('to'))
 let changed = (x, y) => !_.isEqual(x, y) && !(F.isBlank(x) && F.isBlank(y))
 let Command = F.aspects.command(x => y => extendObservable(y, x))
 let fieldPath = _.flow(F.intersperse('fields'), _.compact)


### PR DESCRIPTION
Fixes an issue where removing items from an array goes unnoticed