### PR TITLE
Add path to node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.0
+* Add path to node
+
 # 0.4.3
 * Detect field removals on `getPatch()`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ export default ({
         state.errors = omitByPrefixes(dotPath, state.errors)
       },
     })
+    node.path = rootPath
 
     // config.value acts as a default value
     if (_.isUndefined(node.value) && !_.isUndefined(config.value))


### PR DESCRIPTION
For one, it acts as a unique identifier for the node in the form