### PR TITLE
Take array of reactions and merge their disposers with the form disposers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.0
+* Take form reactions and merge disposers
+
 # 0.5.0
 * Add path to node
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.4.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default ({
   value,
   afterInitField = x => x,
   validate = validators.functions,
+  reactions = () => _.noop,
   ...config
 }) => {
   let saved = {}
@@ -147,6 +148,8 @@ export default ({
     },
   })
 
+  let disposer = _.over(reactions(form))
+  form.dispose = F.aspectSync({ after: disposer })(form.dispose)
   form.reset = F.aspectSync({
     before: () => (form.submit.state.error = null),
   })(form.reset)


### PR DESCRIPTION
Sometimes clients setup reactions on the form, and the code follows this flow:
1. Initialize the form
2. Setup reactions on it
3. Make sure to call both `form.dispose` and the disposer from the reactions

The above has the disadvantage that because the reactions have to be setup post-initialization, every user of the form has to remember to additionally setup the reactions

This PR makes it so we can use the same flow as a form without reactions:
1. Initialize the form and pass reactions
2. Make sure to call `form.dispose`