### PR TITLE
Add getDisposer callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.8.0
-* Add `onAddedField` callback
+* Add `getDisposer` callback
 
 # 0.7.0
 * Pass `form` to validator function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.8.0
+* Add `onAddedField` callback
+
 # 0.7.0
 * Pass `form` to validator function
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default ({
   let state = observable({ value, errors: {} })
 
   let collectDisposers = F.walk(x => x.fields)(node => {
-    node.dispose = node.onAddedField(form, node)
+    node.dispose = node.getDisposer(form, node)
   })
 
   let invokeDisposers = F.walk(x => x.fields)(node => {
@@ -46,7 +46,7 @@ export default ({
   }
 
   let initField = (
-    { fields, onAddedField = _.noop, ...config },
+    { fields, getDisposer = _.noop, ...config },
     rootPath = []
   ) => {
     let dotPath = _.join('.', rootPath)
@@ -90,10 +90,10 @@ export default ({
       getField(path) {
         return _.get(safeJoinPaths(fieldPath(tokenizePath(path))), node.fields)
       },
-      onAddedField(form) {
+      getDisposer(form) {
         return _.over(
           _.compact([
-            onAddedField(form),
+            getDisposer(form),
             // Recreate all array fields on array size changes
             node.itemField &&
               reaction(

--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@ export default ({
   let state = observable({ value, errors: {} })
 
   let collectDisposers = F.walk(x => x.fields)(node => {
-    node.dispose = node.onAddedField(form, node)
+    node._dispose = node.onAddedField(form, node)
   })
 
   let invokeDisposers = F.walk(x => x.fields)(node => {
-    node.dispose()
-    node.dispose = undefined
+    node._dispose()
+    node._dispose = undefined
   })
 
   let recreateArrayFields = node => {

--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@ export default ({
   let state = observable({ value, errors: {} })
 
   let collectDisposers = F.walk(x => x.fields)(node => {
-    node._dispose = node.onAddedField(form, node)
+    node.dispose = node.onAddedField(form, node)
   })
 
   let invokeDisposers = F.walk(x => x.fields)(node => {
-    node._dispose()
-    node._dispose = undefined
+    node.dispose()
+    node.dispose = undefined
   })
 
   let recreateArrayFields = node => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -297,16 +297,16 @@ describe('Methods and computeds', () => {
 })
 
 describe('Disposers', () => {
-  it('Runs onAddedField on form init', () => {
+  it('Runs getDisposer on form init', () => {
     let onAddedForm = jest.fn()
     let onAddedObj = jest.fn()
     let onAddedNested = jest.fn()
     let form = Form({
-      onAddedField: onAddedForm,
+      getDisposer: onAddedForm,
       fields: {
         obj: {
-          onAddedField: onAddedObj,
-          fields: { nested: { onAddedField: onAddedNested } },
+          getDisposer: onAddedObj,
+          fields: { nested: { getDisposer: onAddedNested } },
         },
       },
     })
@@ -315,31 +315,31 @@ describe('Disposers', () => {
     expect(onAddedNested).toHaveBeenCalledWith(form)
   })
 
-  it('Runs onAddedField on adding object field', () => {
+  it('Runs getDisposer on adding object field', () => {
     let form = Form({ fields: {} })
     let onAddedObj = jest.fn()
     let onAddedNested = jest.fn()
     form.add({
       field: {
-        onAddedField: onAddedObj,
-        fields: { nested: { onAddedField: onAddedNested } },
+        getDisposer: onAddedObj,
+        fields: { nested: { getDisposer: onAddedNested } },
       },
     })
     expect(onAddedObj).toHaveBeenCalledWith(form)
     expect(onAddedNested).toHaveBeenCalledWith(form)
   })
 
-  it('Runs onAddedField on adding array field', () => {
-    let onAddedField = jest.fn()
+  it('Runs getDisposer on adding array field', () => {
+    let getDisposer = jest.fn()
     let onAddedNested = jest.fn()
     let form = Form({
       itemField: {
-        onAddedField,
-        fields: { nested: { onAddedField: onAddedNested } },
+        getDisposer,
+        fields: { nested: { getDisposer: onAddedNested } },
       },
     })
     form.value = [{ nested: 1 }]
-    expect(onAddedField).toHaveBeenCalledWith(form)
+    expect(getDisposer).toHaveBeenCalledWith(form)
     expect(onAddedNested).toHaveBeenCalledWith(form)
   })
 
@@ -348,12 +348,12 @@ describe('Disposers', () => {
     let objDisposer = jest.fn()
     let nestedDisposer = jest.fn()
     let form = Form({
-      onAddedField: () => formDisposer,
+      getDisposer: () => formDisposer,
       fields: {
         obj: {
-          onAddedField: () => objDisposer,
+          getDisposer: () => objDisposer,
           itemField: {
-            fields: { nested: { onAddedField: () => nestedDisposer } },
+            fields: { nested: { getDisposer: () => nestedDisposer } },
           },
         },
       },
@@ -371,8 +371,8 @@ describe('Disposers', () => {
     let form = Form({
       fields: {
         obj: {
-          onAddedField: () => objDisposer,
-          fields: { nested: { onAddedField: () => nestedDisposer } },
+          getDisposer: () => objDisposer,
+          fields: { nested: { getDisposer: () => nestedDisposer } },
         },
       },
     })
@@ -387,9 +387,9 @@ describe('Disposers', () => {
     let form = Form({
       fields: {
         top: {
-          onAddedField: () => topDisposer,
+          getDisposer: () => topDisposer,
           itemField: {
-            fields: { nested: { onAddedField: () => nestedDisposer } },
+            fields: { nested: { getDisposer: () => nestedDisposer } },
           },
         },
       },

--- a/src/util.js
+++ b/src/util.js
@@ -20,5 +20,7 @@ export let safeJoinPaths = _.flow(
 // TODO: futil F.mapTree
 export let gatherFormValues = reduceTreePost(x => x.fields)((tree, x, ...xs) =>
   // Only walk leaf nodes
-  !_.isEmpty(x.fields) ? tree : _.set(treePath(x, ...xs), x.value, tree)
+  !_.isEmpty(x.fields) || x.doNotIncludeInSnapshot
+    ? tree
+    : _.set(treePath(x, ...xs), x.value, tree)
 )({})

--- a/src/util.js
+++ b/src/util.js
@@ -20,7 +20,5 @@ export let safeJoinPaths = _.flow(
 // TODO: futil F.mapTree
 export let gatherFormValues = reduceTreePost(x => x.fields)((tree, x, ...xs) =>
   // Only walk leaf nodes
-  !_.isEmpty(x.fields) || x.doNotIncludeInSnapshot
-    ? tree
-    : _.set(treePath(x, ...xs), x.value, tree)
+  !_.isEmpty(x.fields) ? tree : _.set(treePath(x, ...xs), x.value, tree)
 )({})


### PR DESCRIPTION
`getDisposer` is specified per-field and gets run once after the field is added but after all the other fields which were added at the same time have already been initialized. This means that on form initialization, it gets run after the entire form has been initialized.

If a function is returned from `getDisposer`, it's assumed to be a disposer and it gets run whenever the field is removed. Also when any parent field is removed.

`field.dispose()` is still set on the node but it's not meant to be run manually. Instead we should call `remove()` to invoke the disposers.