### PR TITLE
Do not set fields property on array fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.1
+* Do not add a default `fields` property on array fields.
+
 # 0.9.0
 * Allow for data-testid on form elements. If no identifier is passed "unknown" will be assumed as the namespace
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Ridiculously simple form state management with mobx",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ export default ({
       return _.isEmpty(path)
         ? field
         : set(['fields', ...fieldPath(path)], field, tree)
-    })({})(clone(_.defaults({ fields: {} }, config)))
+    })({})(clone(config))
 
   let form = extendObservable(initTree(autoFormConfig), {
     // Ideally we'd just do toJS(form.value) but we have to maintain backwards


### PR DESCRIPTION
A field that represents an array of primitives should not have a `fields` property on it