### PR TITLE
[FEAT] give errors from submit() exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.0
+
+- Support form errors via an `ValidationError` on `submit`.
+
 # 0.13.2
 
 - Do not extend submit when already present

--- a/README.md
+++ b/README.md
@@ -219,3 +219,7 @@ export let CommandButton = observer(({command, children}) => (
   </button>
 ))
 ```
+
+## Capturing submission errors
+
+Custom errors can be captured from `form.submit()` by throwing `ValidationError("Submission failed", errors)`. The `errros` object is of the same shape as the errors given by `validate()` on the form, that is, the keys are the fields and the values are arrays of errors for the field. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Ridiculously simple form state management with mobx",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -387,6 +387,7 @@ describe('submit()', () => {
     await form.submit()
     expect(form.submit.state.status).toBe('failed')
     expect(form.submit.state.error).toBe('Validation Error')
+    expect(form.submitError).toBe('Validation Error')
   })
   it('succeeds when validation and submit() run', async () => {
     const submit = () => {
@@ -397,7 +398,7 @@ describe('submit()', () => {
     expect(form.submit.state.status).toBe('succeeded')
     expect(result).toBe('submit run')
   })
-  it('has errors when submit throws with cause', async () => {
+  it('has errors when submit throws with ValidationError', async () => {
     const submit = () => {
       throw new ValidationError('My submit failed', {
         'location.addresses.0.tenants.0': ['invalid format'],
@@ -413,6 +414,7 @@ describe('submit()', () => {
     expect(form.errors).toEqual({
       'location.addresses.0.tenants.0': ['invalid format'],
     })
+    expect(form.submitError).toBe('My submit failed')
     expect(result).toBeUndefined()
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp.js'
-import { reaction } from 'mobx'
-import Form, { jsonSchemaKeys } from './index.js'
+import { reaction, runInAction } from 'mobx'
+import Form, { jsonSchemaKeys, ValidationError } from './index.js'
 import { toJS } from './mobx.js'
 
 require('util').inspect.defaultOptions.depth = null
@@ -299,7 +299,9 @@ describe('Methods and computeds', () => {
   describe('getPatch()', () => {
     it('Array fields', () => {
       let addresses = form.getField('location.addresses')
-      addresses.value.push({ street: undefined, tenants: undefined })
+      runInAction(() => {
+        addresses.value.push({ street: undefined, tenants: undefined })
+      })
       // Ignores undefined values
       expect(form.getPatch()).toStrictEqual({})
       // Picks up new values
@@ -334,5 +336,83 @@ describe('Methods and computeds', () => {
       form.reset()
       expect(form.getPatch()).toStrictEqual({})
     })
+  })
+})
+
+let goodFields = {
+  location: {
+    fields: {
+      'country.state': {
+        label: 'Dotted field name',
+        fields: {
+          zip: {},
+          name: {},
+        },
+      },
+      addresses: {
+        label: 'Array field',
+        itemField: {
+          label: 'Item field is a record',
+          fields: {
+            street: {},
+            tenants: {
+              label: 'Array field',
+              itemField: {
+                label: 'Item field is a primitive',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+let goodValue = {
+  location: {
+    'country.state': { zip: '07016' },
+    addresses: [{ street: 'Meridian', tenants: ['John'] }],
+  },
+}
+
+describe('submit()', () => {
+  let form = null
+
+  afterEach(() => form.dispose())
+  it('fails when validation fails', async () => {
+    const submit = async () => {
+      return true
+    }
+    form = Form({ fields, value, submit })
+    await form.submit()
+    expect(form.submit.state.status).toBe('failed')
+    expect(form.submit.state.error).toBe('Validation Error')
+  })
+  it('succeeds when validation and submit() run', async () => {
+    const submit = () => {
+      return 'submit run'
+    }
+    form = Form({ fields: goodFields, value: goodValue, submit })
+    const result = await form.submit()
+    expect(form.submit.state.status).toBe('succeeded')
+    expect(result).toBe('submit run')
+  })
+  it('has errors when submit throws with cause', async () => {
+    const submit = () => {
+      throw new ValidationError('My submit failed', 
+         { 'location.addresses.0.tenants.0': ['invalid format'] }
+      )
+    }
+    form = Form({ fields: goodFields, value: goodValue, submit })
+    const result = await form.submit()
+    expect(form.submit.state.status).toBe('failed')
+    expect(form.submit.state.error.message).toBe('My submit failed')
+    expect(form.submit.state.error.cause).toEqual({
+      'location.addresses.0.tenants.0': ['invalid format'],
+    })
+    expect(form.errors).toEqual({
+      'location.addresses.0.tenants.0': ['invalid format'],
+    })
+    expect(result).toBeUndefined()
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -389,7 +389,7 @@ describe('submit()', () => {
     expect(form.submit.state.error).toBe('Validation Error')
     expect(form.submitError).toBe('Validation Error')
   })
-  it('succeeds when validation and submit() run', async () => {
+  it('succeeds when validation and sync submit() run', async () => {
     const submit = () => {
       return 'submit run'
     }
@@ -398,8 +398,36 @@ describe('submit()', () => {
     expect(form.submit.state.status).toBe('succeeded')
     expect(result).toBe('submit run')
   })
-  it('has errors when submit throws with ValidationError', async () => {
+  it('succeeds when validation and async submit() run', async () => {
+    const submit = async () => {
+      return 'submit run'
+    }
+    form = Form({ fields: goodFields, value: goodValue, submit })
+    const result = await form.submit()
+    expect(form.submit.state.status).toBe('succeeded')
+    expect(result).toBe('submit run')
+  })
+  it('has errors when sync submit throws with ValidationError', async () => {
     const submit = () => {
+      throw new ValidationError('My submit failed', {
+        'location.addresses.0.tenants.0': ['invalid format'],
+      })
+    }
+    form = Form({ fields: goodFields, value: goodValue, submit })
+    const result = await form.submit()
+    expect(form.submit.state.status).toBe('failed')
+    expect(form.submit.state.error.message).toBe('My submit failed')
+    expect(form.submit.state.error.cause).toEqual({
+      'location.addresses.0.tenants.0': ['invalid format'],
+    })
+    expect(form.errors).toEqual({
+      'location.addresses.0.tenants.0': ['invalid format'],
+    })
+    expect(form.submitError).toBe('My submit failed')
+    expect(result).toBeUndefined()
+  })
+  it('has errors when async submit throws with ValidationError', async () => {
+    const submit = async () => {
       throw new ValidationError('My submit failed', {
         'location.addresses.0.tenants.0': ['invalid format'],
       })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -421,6 +421,7 @@ describe('submit()', () => {
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.errors).toEqual({
+      '': 'My submit failed',
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.submitError).toBe('My submit failed')
@@ -440,6 +441,7 @@ describe('submit()', () => {
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.errors).toEqual({
+      '': 'My submit failed',
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.submitError).toBe('My submit failed')

--- a/src/util.js
+++ b/src/util.js
@@ -25,3 +25,11 @@ export let gatherFormValues = form =>
       ? tree
       : _.set(treePath(x, ...xs), x.value, tree)
   )({})(form)
+
+  export class ValidationError extends Error {
+      name = 'ValidationError'
+    constructor(message, errors) {
+      super(message)
+      this.cause = errors
+    }
+  }


### PR DESCRIPTION
[GS-8643](https://govspend.atlassian.net/browse/GS-8643)

The exception thrown by `form.submit()` can also be used to populate errors on the fields.

Usage:

```
import {ValidationError} from 'mobx-autoform'
submit = (snapshot, form) => {
// `errors` is an object where the keys are the fields and the values are arrays of errors for the field.
const errors = {}
throw new ValidationError("Submission failed", errors)
}
```