### PR TITLE
FIX: do not have special handling for top level errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.1
+
+- FIX: errors[''] is nothing special, remove special handling for it.
+
 # 0.14.0
 
 - Support form errors via an `ValidationError` on `submit`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Ridiculously simple form state management with mobx",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ export default ({
         return await configSubmit(form.getSnapshot(), form)
       } catch (err) {
         if (err instanceof ValidationError) {
-          state.errors = { '': err.message, ...err.cause }
+          state.errors = err.cause
         }
         throw err
       }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -430,7 +430,7 @@ describe('submit()', () => {
     const submit = async () => {
       throw new ValidationError('My submit failed', {
         'location.addresses.0.tenants.0': ['invalid format'],
-        '': ['top level error']
+        '': ['top level error'],
       })
     }
     form = Form({ fields: goodFields, value: goodValue, submit })
@@ -439,11 +439,11 @@ describe('submit()', () => {
     expect(form.submit.state.error.message).toBe('My submit failed')
     expect(form.submit.state.error.cause).toEqual({
       'location.addresses.0.tenants.0': ['invalid format'],
-      '': ['top level error']
+      '': ['top level error'],
     })
     expect(form.errors).toEqual({
       'location.addresses.0.tenants.0': ['invalid format'],
-      '': ['top level error']
+      '': ['top level error'],
     })
     expect(form.submitError).toBe('My submit failed')
     expect(result).toBeUndefined()

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -421,7 +421,6 @@ describe('submit()', () => {
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.errors).toEqual({
-      '': 'My submit failed',
       'location.addresses.0.tenants.0': ['invalid format'],
     })
     expect(form.submitError).toBe('My submit failed')
@@ -431,6 +430,7 @@ describe('submit()', () => {
     const submit = async () => {
       throw new ValidationError('My submit failed', {
         'location.addresses.0.tenants.0': ['invalid format'],
+        '': ['top level error']
       })
     }
     form = Form({ fields: goodFields, value: goodValue, submit })
@@ -439,10 +439,11 @@ describe('submit()', () => {
     expect(form.submit.state.error.message).toBe('My submit failed')
     expect(form.submit.state.error.cause).toEqual({
       'location.addresses.0.tenants.0': ['invalid format'],
+      '': ['top level error']
     })
     expect(form.errors).toEqual({
-      '': 'My submit failed',
       'location.addresses.0.tenants.0': ['invalid format'],
+      '': ['top level error']
     })
     expect(form.submitError).toBe('My submit failed')
     expect(result).toBeUndefined()


### PR DESCRIPTION
There were two problems with earlier implementation

* `errors['']` does not have any special meaning, so should not be handled separately
* Also,  `errors` should be of the form `Record<string, string[]>` but was implemented as `errors[''] = <string>`