### PR TITLE
[DRAFT] FIX: update errors properly for remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.2
+
+- FIX: remove() removes all errors, not just the removed field.
+
 # 0.14.1
 
 - FIX: errors[''] is nothing special, remove special handling for it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Ridiculously simple form state management with mobx",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default ({
           F.unsetOn(node.field, parent[keys.fields])
         }
         // Clean errors for this field and all subfields
-        state.errors = omitByPrefixes(dotPath, state.errors)
+        state.errors = omitByPrefixes([dotPath], state.errors)
       },
     })
     node.path = rootPath

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -192,7 +192,7 @@ describe('Methods and computeds', () => {
     expect(tenants.fields).toEqual([])
     expect(tenants.value).toEqual([])
     expect(_.size(form.errors)).toBe(1)
-    
+
     tenants.remove()
     expect(form.getField('location.addresses.0.tenants')).toBeUndefined()
     expect(form.getField('location.addresses.0').value).toEqual({

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -185,11 +185,14 @@ describe('Methods and computeds', () => {
   })
 
   it('remove()', () => {
+    form.validate()
+    expect(_.size(form.errors)).toBe(2)
     form.getField('location.addresses.0.tenants.0').remove()
     let tenants = form.getField('location.addresses.0.tenants')
     expect(tenants.fields).toEqual([])
     expect(tenants.value).toEqual([])
-
+    expect(_.size(form.errors)).toBe(1)
+    
     tenants.remove()
     expect(form.getField('location.addresses.0.tenants')).toBeUndefined()
     expect(form.getField('location.addresses.0').value).toEqual({


### PR DESCRIPTION
BUG:

On `remove()`, `state.errros` is empty. This is because `omitByPrefixes` expects a list of paths. Now its corrected.

Added test.

- [ ] Handle errors from array fields