### PR TITLE
FIX: Update errors correctly on array item remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.3
+
+- FIX: On removing an array item, corresponding errors must also be spliced.
+
 # 0.14.2
 
 - FIX: remove() removes all errors, not just the removed field.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-autoform",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Ridiculously simple form state management with mobx",
   "type": "module",
   "main": "dist/cjs/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -40,11 +40,11 @@ let defaultGetSnapshot = form => F.flattenObject(toJS(gatherFormValues(form)))
 let defaultGetNestedSnapshot = form => F.unflattenObject(form.getSnapshot())
 
 // Splice the form errors when a array item is removed
-const spliceErrors = (errors, parent, nodePosition) => {
-  const parentPath = parent.join('.')
-  const parentLength = parent.length
-  const arrayErrors = pickByPrefixes([parentPath], errors)
-  const newErrors = omitByPrefixes([parentPath], errors)
+const spliceErrors = (errors, parentPath, nodePosition) => {
+  const parent = parentPath.join('.')
+  const parentLength = parentPath.length
+  const arrayErrors = pickByPrefixes([parent], errors)
+  const newErrors = omitByPrefixes([parent], errors)
   for (const [key, value] of Object.entries(arrayErrors)) {
     const keyFields = key.split('.')
     const idx = parseInt(keyFields[parentLength])


### PR DESCRIPTION
Follow up upon #75 

When an array item is removed, the error associated with that array item needs to be removed, and the rest of the errors in the array need to be moved up.